### PR TITLE
feat: add multi-framework support for Microsoft Testing Platform

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -159,46 +159,32 @@ jobs:
         if: inputs.hasTests == true && inputs.useMtpRunner == false
         run: dotnet test --no-restore
 
-      - name: Extract Target Frameworks
-        if: inputs.hasTests == true && inputs.useMtpRunner == true
-        id: extract-frameworks
-        run: |
-          echo "🎯 Extracting target frameworks from dotnetVersion..."
-          
-          # Convert dotnetVersion input to target framework monikers
-          FRAMEWORKS=""
-          DOTNET_VERSIONS="${{ inputs.dotnetVersion }}"
-          
-          # Handle both single string and multi-line input
-          for version in $DOTNET_VERSIONS; do
-            # Extract major.minor version and convert to target framework
-            if [[ "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
-              MAJOR="${BASH_REMATCH[1]}"
-              MINOR="${BASH_REMATCH[2]}"
-              TFM="net${MAJOR}.${MINOR}"
-              FRAMEWORKS="$FRAMEWORKS $TFM"
-              echo "✅ Mapped $version → $TFM"
-            fi
-          done
-          
-          echo "📋 Target frameworks: $FRAMEWORKS"
-          echo "frameworks=$FRAMEWORKS" >> $GITHUB_OUTPUT
-
       - name: Test Code (MTP)
         if: inputs.hasTests == true && inputs.useMtpRunner == true
         run: |
           echo "🧪 Running MTP tests for deployment..."
+          
+          # Convert dotnetVersion input to target framework monikers and run tests
+          DOTNET_VERSIONS="${{ inputs.dotnetVersion }}"
           
           # Run each discovered test project for each target framework
           for project in ${{ steps.discover-tests.outputs.test-projects }}; do
             PROJECT_NAME=$(basename "$project" .csproj)
             echo "🏃 Running tests for: $PROJECT_NAME"
             
-            for framework in ${{ steps.extract-frameworks.outputs.frameworks }}; do
-              echo "🎯 Testing $PROJECT_NAME with framework: $framework"
-              
-              # Run without coverage for production builds
-              dotnet run --project "$project" --framework "$framework"
+            # Handle both single string and multi-line input
+            for version in $DOTNET_VERSIONS; do
+              # Extract major.minor version and convert to target framework
+              if [[ "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+                MAJOR="${BASH_REMATCH[1]}"
+                MINOR="${BASH_REMATCH[2]}"
+                TFM="net${MAJOR}.${MINOR}"
+                
+                echo "🎯 Testing $PROJECT_NAME with framework: $TFM"
+                
+                # Run without coverage for production builds
+                dotnet run --project "$project" --framework "$TFM"
+              fi
             done
           done
 

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -159,18 +159,47 @@ jobs:
         if: inputs.hasTests == true && inputs.useMtpRunner == false
         run: dotnet test --no-restore
 
+      - name: Extract Target Frameworks
+        if: inputs.hasTests == true && inputs.useMtpRunner == true
+        id: extract-frameworks
+        run: |
+          echo "🎯 Extracting target frameworks from dotnetVersion..."
+          
+          # Convert dotnetVersion input to target framework monikers
+          FRAMEWORKS=""
+          DOTNET_VERSIONS="${{ inputs.dotnetVersion }}"
+          
+          # Handle both single string and multi-line input
+          for version in $DOTNET_VERSIONS; do
+            # Extract major.minor version and convert to target framework
+            if [[ "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+              MAJOR="${BASH_REMATCH[1]}"
+              MINOR="${BASH_REMATCH[2]}"
+              TFM="net${MAJOR}.${MINOR}"
+              FRAMEWORKS="$FRAMEWORKS $TFM"
+              echo "✅ Mapped $version → $TFM"
+            fi
+          done
+          
+          echo "📋 Target frameworks: $FRAMEWORKS"
+          echo "frameworks=$FRAMEWORKS" >> $GITHUB_OUTPUT
+
       - name: Test Code (MTP)
         if: inputs.hasTests == true && inputs.useMtpRunner == true
         run: |
-          echo "🧪 Running MTP tests..."
+          echo "🧪 Running MTP tests for deployment..."
           
-          # Run each discovered test project
+          # Run each discovered test project for each target framework
           for project in ${{ steps.discover-tests.outputs.test-projects }}; do
             PROJECT_NAME=$(basename "$project" .csproj)
             echo "🏃 Running tests for: $PROJECT_NAME"
             
-            # Run without coverage for production builds
-            dotnet run --project "$project"
+            for framework in ${{ steps.extract-frameworks.outputs.frameworks }}; do
+              echo "🎯 Testing $PROJECT_NAME with framework: $framework"
+              
+              # Run without coverage for production builds
+              dotnet run --project "$project" --framework "$framework"
+            done
           done
 
       - name: Setup Local .NET Tools

--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -90,7 +90,7 @@ jobs:
         if: inputs.hasTests == true && inputs.useMtpRunner == true
         id: extract-frameworks
         run: |
-          echo "🎯 Extracting target frameworks from dotnet-version..."
+          echo "🎯 Using provided dotnet-version as target frameworks..."
           
           # Convert dotnet-version input to target framework monikers
           FRAMEWORKS=""
@@ -104,7 +104,7 @@ jobs:
               MINOR="${BASH_REMATCH[2]}"
               TFM="net${MAJOR}.${MINOR}"
               FRAMEWORKS="$FRAMEWORKS $TFM"
-              echo "✅ Mapped $version → $TFM"
+              echo "✅ Using framework: $TFM (from $version)"
             fi
           done
           

--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -20,16 +20,6 @@ on:
         required: false
         default: "tests"
         type: string
-      enableCodeCoverage:
-        description: "Enable code coverage collection"
-        required: false
-        default: false
-        type: boolean
-      coverageThreshold:
-        description: "Minimum code coverage percentage required (0-100)"
-        required: false
-        default: 80
-        type: number
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -128,13 +118,7 @@ jobs:
       - name: Test Code (MTP)
         if: inputs.hasTests == true && inputs.useMtpRunner == true
         run: |
-          echo "🧪 Running MTP tests with coverage: ${{ inputs.enableCodeCoverage }}"
-          
-          # Install ReportGenerator if coverage is enabled
-          if [ "${{ inputs.enableCodeCoverage }}" == "true" ]; then
-            echo "📊 Installing ReportGenerator..."
-            dotnet tool install --global dotnet-reportgenerator-globaltool
-          fi
+          echo "🧪 Running MTP tests..."
           
           # Run each discovered test project for each target framework
           for project in ${{ steps.discover-tests.outputs.test-projects }}; do
@@ -144,81 +128,11 @@ jobs:
             for framework in ${{ steps.extract-frameworks.outputs.frameworks }}; do
               echo "🎯 Testing $PROJECT_NAME with framework: $framework"
               
-              if [ "${{ inputs.enableCodeCoverage }}" == "true" ]; then
-                # Run with coverage - specify absolute path to ensure coverage file is in current directory
-                dotnet run --project "$project" --framework "$framework" -- --coverage --coverage-output-format cobertura --coverage-output "$PWD/coverage-$PROJECT_NAME-$framework.cobertura.xml"
-              else
-                # Run without coverage
-                dotnet run --project "$project" --framework "$framework"
-              fi
+              # Run without coverage
+              dotnet run --project "$project" --framework "$framework"
             done
           done
 
-      - name: Generate Coverage Reports (MTP)
-        if: inputs.hasTests == true && inputs.useMtpRunner == true && inputs.enableCodeCoverage == true
-        run: |
-          echo "📊 Generating combined coverage reports from multiple frameworks..."
-          
-          # Check if any coverage files exist (now includes framework suffix)
-          if ! ls coverage-*-*.cobertura.xml 1> /dev/null 2>&1; then
-            echo "❌ No multi-framework coverage files found!"
-            # Fallback: check for old single-framework format
-            if ! ls coverage-*.cobertura.xml 1> /dev/null 2>&1; then
-              echo "❌ No coverage files found at all!"
-              exit 1
-            else
-              echo "📋 Found single-framework coverage files, using those..."
-            fi
-          fi
-          
-          # List all coverage files for debugging
-          echo "📋 Coverage files found:"
-          ls -la coverage-*.cobertura.xml || true
-          
-          # Combine all coverage files and generate reports (supports both formats)
-          reportgenerator -reports:"coverage-*.cobertura.xml" -targetdir:"CoverageReport" -reporttypes:"Html;Cobertura;TextSummary"
-          
-          # Extract coverage percentage from the summary
-          if [ -f "CoverageReport/Summary.txt" ]; then
-            COVERAGE=$(grep "Line coverage:" "CoverageReport/Summary.txt" | grep -oE "[0-9]+\.[0-9]+%" | head -1 | sed 's/%//')
-            if [ -z "$COVERAGE" ]; then
-              echo "⚠️  Could not extract coverage percentage, checking for alternative format..."
-              COVERAGE=$(grep -E "Line coverage.*[0-9]+\.[0-9]+%" "CoverageReport/Summary.txt" | grep -oE "[0-9]+\.[0-9]+" | head -1)
-            fi
-          else
-            echo "⚠️  Summary.txt not found, attempting to extract from XML..."
-            COVERAGE=$(grep -E "line-rate=\"[0-9]+\.[0-9]+\"" coverage-*.cobertura.xml | head -1 | grep -oE "[0-9]+\.[0-9]+" | head -1)
-            if [ -n "$COVERAGE" ]; then
-              # Convert from decimal to percentage
-              COVERAGE=$(echo "$COVERAGE * 100" | bc -l | sed 's/\.[0-9]*$//')
-            fi
-          fi
-          
-          if [ -n "$COVERAGE" ]; then
-            echo "📈 Combined coverage across all frameworks: $COVERAGE%"
-            echo "🎯 Required threshold: ${{ inputs.coverageThreshold }}%"
-            
-            # Compare coverage with threshold
-            if (( $(echo "$COVERAGE < ${{ inputs.coverageThreshold }}" | bc -l) )); then
-              echo "❌ Coverage $COVERAGE% is below threshold ${{ inputs.coverageThreshold }}%"
-              echo "::error::Code coverage $COVERAGE% is below the required threshold of ${{ inputs.coverageThreshold }}%"
-              exit 1
-            else
-              echo "✅ Combined coverage $COVERAGE% meets threshold ${{ inputs.coverageThreshold }}%"
-            fi
-          else
-            echo "⚠️  Could not determine coverage percentage, but reports were generated"
-          fi
-
-      - name: Upload Coverage Reports
-        if: inputs.hasTests == true && inputs.enableCodeCoverage == true
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-reports
-          path: |
-            CoverageReport/
-            coverage-*.cobertura.xml
-          retention-days: 30
 
       - name: Pack
         run: dotnet pack --configuration Release -o artifacts --no-build /p:Version=${{ env.VERSION }}

--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -5,6 +5,31 @@ on:
       dotnet-version:
         type: string
         default: "8.0.x"
+      hasTests:
+        description: "Determines if tests should be run"
+        required: false
+        default: true
+        type: boolean
+      useMtpRunner:
+        description: "Use Microsoft Testing Platform runner (dotnet run) instead of legacy dotnet test"
+        required: false
+        default: false
+        type: boolean
+      testDirectory:
+        description: "Directory containing test projects"
+        required: false
+        default: "tests"
+        type: string
+      enableCodeCoverage:
+        description: "Enable code coverage collection"
+        required: false
+        default: false
+        type: boolean
+      coverageThreshold:
+        description: "Minimum code coverage percentage required (0-100)"
+        required: false
+        default: 80
+        type: number
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -31,8 +56,169 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
-      - name: Test
+      - name: Discover Test Projects (MTP)
+        if: inputs.hasTests == true && inputs.useMtpRunner == true
+        id: discover-tests
+        run: |
+          echo "🔍 Discovering test projects in ${{ inputs.testDirectory }} directory..."
+          
+          TEST_PROJECTS=""
+          TOTAL_FOUND=0
+          TOTAL_SKIPPED=0
+          
+          for csproj in $(find ${{ inputs.testDirectory }} -name "*.csproj" -type f 2>/dev/null || true); do
+            TOTAL_FOUND=$((TOTAL_FOUND + 1))
+            PROJECT_NAME=$(basename "$csproj" .csproj)
+            
+            # Check if project has IsTestProject=false
+            if grep -q "<IsTestProject>false</IsTestProject>" "$csproj"; then
+              echo "⏭️  Skipping utility project: $PROJECT_NAME"
+              TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+              continue
+            fi
+            
+            # Check if project has MTP runner enabled
+            if grep -q "UseMicrosoftTestingPlatformRunner.*true" "$csproj"; then
+              echo "✅ Found MTP test project: $PROJECT_NAME"
+              TEST_PROJECTS="$TEST_PROJECTS $csproj"
+            else
+              echo "⚠️  Project $PROJECT_NAME doesn't have MTP runner enabled"
+              TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+            fi
+          done
+          
+          echo "📊 Summary: Found $TOTAL_FOUND projects, using $((TOTAL_FOUND - TOTAL_SKIPPED)), skipped $TOTAL_SKIPPED"
+          echo "test-projects=$TEST_PROJECTS" >> $GITHUB_OUTPUT
+          
+          # Validate we found at least one test project
+          if [ -z "$TEST_PROJECTS" ]; then
+            echo "❌ No MTP test projects found!"
+            exit 1
+          fi
+
+      - name: Extract Target Frameworks
+        if: inputs.hasTests == true && inputs.useMtpRunner == true
+        id: extract-frameworks
+        run: |
+          echo "🎯 Extracting target frameworks from dotnet-version..."
+          
+          # Convert dotnet-version input to target framework monikers
+          FRAMEWORKS=""
+          DOTNET_VERSIONS="${{ inputs.dotnet-version }}"
+          
+          # Handle both single string and multi-line input
+          for version in $DOTNET_VERSIONS; do
+            # Extract major.minor version and convert to target framework
+            if [[ "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+              MAJOR="${BASH_REMATCH[1]}"
+              MINOR="${BASH_REMATCH[2]}"
+              TFM="net${MAJOR}.${MINOR}"
+              FRAMEWORKS="$FRAMEWORKS $TFM"
+              echo "✅ Mapped $version → $TFM"
+            fi
+          done
+          
+          echo "📋 Target frameworks: $FRAMEWORKS"
+          echo "frameworks=$FRAMEWORKS" >> $GITHUB_OUTPUT
+
+      - name: Test Code (Legacy)
+        if: inputs.hasTests == true && inputs.useMtpRunner == false
         run: dotnet test --no-restore
+
+      - name: Test Code (MTP)
+        if: inputs.hasTests == true && inputs.useMtpRunner == true
+        run: |
+          echo "🧪 Running MTP tests with coverage: ${{ inputs.enableCodeCoverage }}"
+          
+          # Install ReportGenerator if coverage is enabled
+          if [ "${{ inputs.enableCodeCoverage }}" == "true" ]; then
+            echo "📊 Installing ReportGenerator..."
+            dotnet tool install --global dotnet-reportgenerator-globaltool
+          fi
+          
+          # Run each discovered test project for each target framework
+          for project in ${{ steps.discover-tests.outputs.test-projects }}; do
+            PROJECT_NAME=$(basename "$project" .csproj)
+            echo "🏃 Running tests for: $PROJECT_NAME"
+            
+            for framework in ${{ steps.extract-frameworks.outputs.frameworks }}; do
+              echo "🎯 Testing $PROJECT_NAME with framework: $framework"
+              
+              if [ "${{ inputs.enableCodeCoverage }}" == "true" ]; then
+                # Run with coverage - specify absolute path to ensure coverage file is in current directory
+                dotnet run --project "$project" --framework "$framework" -- --coverage --coverage-output-format cobertura --coverage-output "$PWD/coverage-$PROJECT_NAME-$framework.cobertura.xml"
+              else
+                # Run without coverage
+                dotnet run --project "$project" --framework "$framework"
+              fi
+            done
+          done
+
+      - name: Generate Coverage Reports (MTP)
+        if: inputs.hasTests == true && inputs.useMtpRunner == true && inputs.enableCodeCoverage == true
+        run: |
+          echo "📊 Generating combined coverage reports from multiple frameworks..."
+          
+          # Check if any coverage files exist (now includes framework suffix)
+          if ! ls coverage-*-*.cobertura.xml 1> /dev/null 2>&1; then
+            echo "❌ No multi-framework coverage files found!"
+            # Fallback: check for old single-framework format
+            if ! ls coverage-*.cobertura.xml 1> /dev/null 2>&1; then
+              echo "❌ No coverage files found at all!"
+              exit 1
+            else
+              echo "📋 Found single-framework coverage files, using those..."
+            fi
+          fi
+          
+          # List all coverage files for debugging
+          echo "📋 Coverage files found:"
+          ls -la coverage-*.cobertura.xml || true
+          
+          # Combine all coverage files and generate reports (supports both formats)
+          reportgenerator -reports:"coverage-*.cobertura.xml" -targetdir:"CoverageReport" -reporttypes:"Html;Cobertura;TextSummary"
+          
+          # Extract coverage percentage from the summary
+          if [ -f "CoverageReport/Summary.txt" ]; then
+            COVERAGE=$(grep "Line coverage:" "CoverageReport/Summary.txt" | grep -oE "[0-9]+\.[0-9]+%" | head -1 | sed 's/%//')
+            if [ -z "$COVERAGE" ]; then
+              echo "⚠️  Could not extract coverage percentage, checking for alternative format..."
+              COVERAGE=$(grep -E "Line coverage.*[0-9]+\.[0-9]+%" "CoverageReport/Summary.txt" | grep -oE "[0-9]+\.[0-9]+" | head -1)
+            fi
+          else
+            echo "⚠️  Summary.txt not found, attempting to extract from XML..."
+            COVERAGE=$(grep -E "line-rate=\"[0-9]+\.[0-9]+\"" coverage-*.cobertura.xml | head -1 | grep -oE "[0-9]+\.[0-9]+" | head -1)
+            if [ -n "$COVERAGE" ]; then
+              # Convert from decimal to percentage
+              COVERAGE=$(echo "$COVERAGE * 100" | bc -l | sed 's/\.[0-9]*$//')
+            fi
+          fi
+          
+          if [ -n "$COVERAGE" ]; then
+            echo "📈 Combined coverage across all frameworks: $COVERAGE%"
+            echo "🎯 Required threshold: ${{ inputs.coverageThreshold }}%"
+            
+            # Compare coverage with threshold
+            if (( $(echo "$COVERAGE < ${{ inputs.coverageThreshold }}" | bc -l) )); then
+              echo "❌ Coverage $COVERAGE% is below threshold ${{ inputs.coverageThreshold }}%"
+              echo "::error::Code coverage $COVERAGE% is below the required threshold of ${{ inputs.coverageThreshold }}%"
+              exit 1
+            else
+              echo "✅ Combined coverage $COVERAGE% meets threshold ${{ inputs.coverageThreshold }}%"
+            fi
+          else
+            echo "⚠️  Could not determine coverage percentage, but reports were generated"
+          fi
+
+      - name: Upload Coverage Reports
+        if: inputs.hasTests == true && inputs.enableCodeCoverage == true
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            CoverageReport/
+            coverage-*.cobertura.xml
+          retention-days: 30
 
       - name: Pack
         run: dotnet pack --configuration Release -o artifacts --no-build /p:Version=${{ env.VERSION }}

--- a/.github/workflows/package-build.yaml
+++ b/.github/workflows/package-build.yaml
@@ -86,31 +86,6 @@ jobs:
             exit 1
           fi
 
-      - name: Extract Target Frameworks
-        if: inputs.hasTests == true && inputs.useMtpRunner == true
-        id: extract-frameworks
-        run: |
-          echo "🎯 Using provided dotnet-version as target frameworks..."
-          
-          # Convert dotnet-version input to target framework monikers
-          FRAMEWORKS=""
-          DOTNET_VERSIONS="${{ inputs.dotnet-version }}"
-          
-          # Handle both single string and multi-line input
-          for version in $DOTNET_VERSIONS; do
-            # Extract major.minor version and convert to target framework
-            if [[ "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
-              MAJOR="${BASH_REMATCH[1]}"
-              MINOR="${BASH_REMATCH[2]}"
-              TFM="net${MAJOR}.${MINOR}"
-              FRAMEWORKS="$FRAMEWORKS $TFM"
-              echo "✅ Using framework: $TFM (from $version)"
-            fi
-          done
-          
-          echo "📋 Target frameworks: $FRAMEWORKS"
-          echo "frameworks=$FRAMEWORKS" >> $GITHUB_OUTPUT
-
       - name: Test Code (Legacy)
         if: inputs.hasTests == true && inputs.useMtpRunner == false
         run: dotnet test --no-restore
@@ -120,16 +95,27 @@ jobs:
         run: |
           echo "🧪 Running MTP tests..."
           
+          # Convert dotnet-version input to target framework monikers and run tests
+          DOTNET_VERSIONS="${{ inputs.dotnet-version }}"
+          
           # Run each discovered test project for each target framework
           for project in ${{ steps.discover-tests.outputs.test-projects }}; do
             PROJECT_NAME=$(basename "$project" .csproj)
             echo "🏃 Running tests for: $PROJECT_NAME"
             
-            for framework in ${{ steps.extract-frameworks.outputs.frameworks }}; do
-              echo "🎯 Testing $PROJECT_NAME with framework: $framework"
-              
-              # Run without coverage
-              dotnet run --project "$project" --framework "$framework"
+            # Handle both single string and multi-line input
+            for version in $DOTNET_VERSIONS; do
+              # Extract major.minor version and convert to target framework
+              if [[ "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+                MAJOR="${BASH_REMATCH[1]}"
+                MINOR="${BASH_REMATCH[2]}"
+                TFM="net${MAJOR}.${MINOR}"
+                
+                echo "🎯 Testing $PROJECT_NAME with framework: $TFM"
+                
+                # Run without coverage
+                dotnet run --project "$project" --framework "$TFM"
+              fi
             done
           done
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -176,6 +176,31 @@ jobs:
             --configuration Release \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=${{ inputs.coverageReportFormats }}
 
+      - name: Extract Target Frameworks
+        if: inputs.hasTests == true && inputs.useMtpRunner == true
+        id: extract-frameworks
+        run: |
+          echo "🎯 Extracting target frameworks from dotnetVersion..."
+          
+          # Convert dotnetVersion input to target framework monikers
+          FRAMEWORKS=""
+          DOTNET_VERSIONS="${{ inputs.dotnetVersion }}"
+          
+          # Handle both single string and multi-line input
+          for version in $DOTNET_VERSIONS; do
+            # Extract major.minor version and convert to target framework
+            if [[ "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+              MAJOR="${BASH_REMATCH[1]}"
+              MINOR="${BASH_REMATCH[2]}"
+              TFM="net${MAJOR}.${MINOR}"
+              FRAMEWORKS="$FRAMEWORKS $TFM"
+              echo "✅ Mapped $version → $TFM"
+            fi
+          done
+          
+          echo "📋 Target frameworks: $FRAMEWORKS"
+          echo "frameworks=$FRAMEWORKS" >> $GITHUB_OUTPUT
+
       - name: Test Code (MTP)
         if: inputs.hasTests == true && inputs.useMtpRunner == true
         run: |
@@ -187,32 +212,46 @@ jobs:
             dotnet tool install --global dotnet-reportgenerator-globaltool
           fi
           
-          # Run each discovered test project
+          # Run each discovered test project for each target framework
           for project in ${{ steps.discover-tests.outputs.test-projects }}; do
             PROJECT_NAME=$(basename "$project" .csproj)
             echo "🏃 Running tests for: $PROJECT_NAME"
             
-            if [ "${{ inputs.enableCodeCoverage }}" == "true" ]; then
-              # Run with coverage - specify absolute path to ensure coverage file is in current directory
-              dotnet run --project "$project" -- --coverage --coverage-output-format cobertura --coverage-output "$PWD/coverage-$PROJECT_NAME.cobertura.xml"
-            else
-              # Run without coverage
-              dotnet run --project "$project"
-            fi
+            for framework in ${{ steps.extract-frameworks.outputs.frameworks }}; do
+              echo "🎯 Testing $PROJECT_NAME with framework: $framework"
+              
+              if [ "${{ inputs.enableCodeCoverage }}" == "true" ]; then
+                # Run with coverage - specify absolute path to ensure coverage file is in current directory
+                dotnet run --project "$project" --framework "$framework" -- --coverage --coverage-output-format cobertura --coverage-output "$PWD/coverage-$PROJECT_NAME-$framework.cobertura.xml"
+              else
+                # Run without coverage
+                dotnet run --project "$project" --framework "$framework"
+              fi
+            done
           done
 
       - name: Generate Coverage Reports (MTP)
         if: inputs.hasTests == true && inputs.useMtpRunner == true && inputs.enableCodeCoverage == true
         run: |
-          echo "📊 Generating combined coverage reports..."
+          echo "📊 Generating combined coverage reports from multiple frameworks..."
           
-          # Check if any coverage files exist
-          if ! ls coverage-*.cobertura.xml 1> /dev/null 2>&1; then
-            echo "❌ No coverage files found!"
-            exit 1
+          # Check if any coverage files exist (now includes framework suffix)
+          if ! ls coverage-*-*.cobertura.xml 1> /dev/null 2>&1; then
+            echo "❌ No multi-framework coverage files found!"
+            # Fallback: check for old single-framework format
+            if ! ls coverage-*.cobertura.xml 1> /dev/null 2>&1; then
+              echo "❌ No coverage files found at all!"
+              exit 1
+            else
+              echo "📋 Found single-framework coverage files, using those..."
+            fi
           fi
           
-          # Combine all coverage files and generate reports
+          # List all coverage files for debugging
+          echo "📋 Coverage files found:"
+          ls -la coverage-*.cobertura.xml || true
+          
+          # Combine all coverage files and generate reports (supports both formats)
           reportgenerator -reports:"coverage-*.cobertura.xml" -targetdir:"CoverageReport" -reporttypes:"Html;Cobertura;TextSummary"
           
           # Extract coverage percentage from the summary
@@ -232,7 +271,7 @@ jobs:
           fi
           
           if [ -n "$COVERAGE" ]; then
-            echo "📈 Current coverage: $COVERAGE%"
+            echo "📈 Combined coverage across all frameworks: $COVERAGE%"
             echo "🎯 Required threshold: ${{ inputs.coverageThreshold }}%"
             
             # Compare coverage with threshold
@@ -241,7 +280,7 @@ jobs:
               echo "::error::Code coverage $COVERAGE% is below the required threshold of ${{ inputs.coverageThreshold }}%"
               exit 1
             else
-              echo "✅ Coverage $COVERAGE% meets threshold ${{ inputs.coverageThreshold }}%"
+              echo "✅ Combined coverage $COVERAGE% meets threshold ${{ inputs.coverageThreshold }}%"
             fi
           else
             echo "⚠️  Could not determine coverage percentage, but reports were generated"

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -176,31 +176,6 @@ jobs:
             --configuration Release \
             -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=${{ inputs.coverageReportFormats }}
 
-      - name: Extract Target Frameworks
-        if: inputs.hasTests == true && inputs.useMtpRunner == true
-        id: extract-frameworks
-        run: |
-          echo "🎯 Extracting target frameworks from dotnetVersion..."
-          
-          # Convert dotnetVersion input to target framework monikers
-          FRAMEWORKS=""
-          DOTNET_VERSIONS="${{ inputs.dotnetVersion }}"
-          
-          # Handle both single string and multi-line input
-          for version in $DOTNET_VERSIONS; do
-            # Extract major.minor version and convert to target framework
-            if [[ "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
-              MAJOR="${BASH_REMATCH[1]}"
-              MINOR="${BASH_REMATCH[2]}"
-              TFM="net${MAJOR}.${MINOR}"
-              FRAMEWORKS="$FRAMEWORKS $TFM"
-              echo "✅ Mapped $version → $TFM"
-            fi
-          done
-          
-          echo "📋 Target frameworks: $FRAMEWORKS"
-          echo "frameworks=$FRAMEWORKS" >> $GITHUB_OUTPUT
-
       - name: Test Code (MTP)
         if: inputs.hasTests == true && inputs.useMtpRunner == true
         run: |
@@ -212,20 +187,31 @@ jobs:
             dotnet tool install --global dotnet-reportgenerator-globaltool
           fi
           
+          # Convert dotnetVersion input to target framework monikers and run tests
+          DOTNET_VERSIONS="${{ inputs.dotnetVersion }}"
+          
           # Run each discovered test project for each target framework
           for project in ${{ steps.discover-tests.outputs.test-projects }}; do
             PROJECT_NAME=$(basename "$project" .csproj)
             echo "🏃 Running tests for: $PROJECT_NAME"
             
-            for framework in ${{ steps.extract-frameworks.outputs.frameworks }}; do
-              echo "🎯 Testing $PROJECT_NAME with framework: $framework"
-              
-              if [ "${{ inputs.enableCodeCoverage }}" == "true" ]; then
-                # Run with coverage - specify absolute path to ensure coverage file is in current directory
-                dotnet run --project "$project" --framework "$framework" -- --coverage --coverage-output-format cobertura --coverage-output "$PWD/coverage-$PROJECT_NAME-$framework.cobertura.xml"
-              else
-                # Run without coverage
-                dotnet run --project "$project" --framework "$framework"
+            # Handle both single string and multi-line input
+            for version in $DOTNET_VERSIONS; do
+              # Extract major.minor version and convert to target framework
+              if [[ "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+                MAJOR="${BASH_REMATCH[1]}"
+                MINOR="${BASH_REMATCH[2]}"
+                TFM="net${MAJOR}.${MINOR}"
+                
+                echo "🎯 Testing $PROJECT_NAME with framework: $TFM"
+                
+                if [ "${{ inputs.enableCodeCoverage }}" == "true" ]; then
+                  # Run with coverage - specify absolute path to ensure coverage file is in current directory
+                  dotnet run --project "$project" --framework "$TFM" -- --coverage --coverage-output-format cobertura --coverage-output "$PWD/coverage-$PROJECT_NAME-$TFM.cobertura.xml"
+                else
+                  # Run without coverage
+                  dotnet run --project "$project" --framework "$TFM"
+                fi
               fi
             done
           done


### PR DESCRIPTION
## Summary
- Add support for testing multiple .NET frameworks with Microsoft Testing Platform
- Enable framework-specific test execution using `dotnet run --framework $TFM`
- Maintain backward compatibility with legacy MSTest runner
- Consistent implementation across all three workflow files

## Changes Made

### pr-build.yaml
- Inline framework extraction from `dotnetVersion` input
- Run MTP tests for each target framework individually
- Generate separate coverage files per framework when enabled
- Combine coverage reports from all frameworks

### build-deploy.yaml
- Same multi-framework support for deployment testing
- Framework-specific test execution for production builds

### package-build.yaml
- Added MTP input parameters (`hasTests`, `useMtpRunner`, `testDirectory`)
- Implemented multi-framework testing capability
- Removed code coverage (not needed for package builds)
- Maintain legacy MSTest support

## Key Features
✅ Multi-framework support - converts SDK versions to framework monikers  
✅ Framework iteration - tests each framework individually  
✅ Combined coverage - merges reports from all frameworks  
✅ Backward compatibility - supports both MSTest and MTP  
✅ Consistent implementation - all workflows use same approach

## Breaking Changes
None - all changes are additive with backward compatibility maintained.

## Test Plan
- [x] Verify framework extraction works with single and multi-line inputs
- [x] Confirm MTP test discovery finds enabled projects
- [x] Validate framework-specific test execution
- [x] Test coverage collection and reporting (where enabled)

🤖 Generated with [Claude Code](https://claude.ai/code)